### PR TITLE
Update to use the Libertinus font (including math)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           
       - name: install font
         run: |
-          tlmgr install libertine && updmap-sys --enable Map=libertine.map
+          tlmgr install libertinus libertinus-otf libertinus-fonts
           
       - name: prepare output directories
         run: |

--- a/pdf-styles/meta_aao-latex.yaml
+++ b/pdf-styles/meta_aao-latex.yaml
@@ -16,6 +16,7 @@ mathfontoptions:
   - AutoFakeBold
 header-includes:
   - \setkomafont{disposition}{\bfseries}
+  - \setkomafont{descriptionlabel}{\normalfont\bfseries}
   - \usepackage{scrlayer-scrpage}
   - \usepackage{titling}
   - \lohead{\small \thedate}

--- a/pdf-styles/meta_aao-latex.yaml
+++ b/pdf-styles/meta_aao-latex.yaml
@@ -6,8 +6,14 @@ classoption:
   - DIV=8
 lang: de-DE
 colorlinks: true
-mainfont: Linux Libertine O
-mathfont: Latin Modern Math
+mainfont: LibertinusSerif-Regular.otf
+mainfontoptions:         
+  - BoldFont = LibertinusSerif-Bold.otf
+  - ItalicFont = LibertinusSerif-Italic.otf
+  - BoldItalicFont = LibertinusSerif-BoldItalic.otf
+mathfont: LibertinusMath-Regular.otf
+mathfontoptions:
+  - AutoFakeBold
 header-includes:
   - \setkomafont{disposition}{\bfseries}
   - \usepackage{scrlayer-scrpage}


### PR DESCRIPTION
Libertinus is a fork and continuation of the Linux Libertine project.

It offers some improvements to the Libertine font but is practically indistinguishable for our average reader.

It also offers a Math variant that blends in nicely with its Serif. This is a huge improvement to texts typed in Libertine.

### With Libertine, without math (our current layout):

<img width="685" height="42" alt="grafik" src="https://github.com/user-attachments/assets/0f7cb850-fade-4e24-b0c3-3ee0e52da686" />


### With Libertinus and Libertinus Math (this PR):

<img width="673" height="41" alt="grafik" src="https://github.com/user-attachments/assets/b66d9ab0-4d40-4f59-a30e-2e9b4acadb2d" />

(Note that Libertinus has dropped the `Th` ligature from Libertine. It's a design decision by the font designers, I don't know exactly why they did it. Maybe to increase multi-lingual use since having `Th` as a ligature makes lots of sense in English but maybe less sense in other languages? I don't know.)

---

This update also removes a call to `updmap-sys` in `build.yml`. `updmap-sys` is a mapping of human-readable font names to font files, such as "Linux Libertine O -> LinLibertine.otf". Calling this mapping can be a bit expensive, but we don't need human readable fonts in a headless system. Simply link to the .otf files directly, e.g. in the YAML config to Pandoc (see changes to `meta_aao-latex.yaml`)
