### PR TITLE
Dependencies for the datetime2 pakage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       
       - name: install TeX packages
         run: |
-          tlmgr install titling datetime2 datetime2-german datetime2-english
+          tlmgr install titling datetime2 datetime2-german datetime2-english tracklang etoolbox xkeyval
           
       - name: install font
         run: |


### PR DESCRIPTION
The `datetime2` package relies on some other packages that I did not include in my previous PR.